### PR TITLE
Fixed issue where setting the controller name might break. Example ticke...

### DIFF
--- a/code/libraries/koowa/libraries/dispatcher/http.php
+++ b/code/libraries/koowa/libraries/dispatcher/http.php
@@ -111,7 +111,7 @@ class KDispatcherHttp extends KDispatcherAbstract implements KObjectInstantiable
         }
         else
         {
-            $this->setController($this->getRequest()->query->get('view', 'alpha'));
+            $this->setController($this->getRequest()->query->get('view', 'cmd'));
 
             //Execute the component method
             $method = strtolower($context->request->getMethod());


### PR DESCRIPTION
...t_type get converted to tickettype.
