### PR TITLE
Improved query escaping.

### DIFF
--- a/code/libraries/koowa/libraries/database/adapter/abstract.php
+++ b/code/libraries/koowa/libraries/database/adapter/abstract.php
@@ -564,7 +564,7 @@ abstract class KDatabaseAdapterAbstract extends KObject implements KDatabaseAdap
         $spec = trim($spec);
     
         // Quote all the lower case parts
-        $spec = preg_replace_callback('/(?:\b|#)+(?<![`:@])([-a-zA-Z0-9.#_]*[a-z][-a-zA-Z0-9.#_]*)(?!`)\b/', array($this, '_quoteIdentifier'), $spec);
+        $spec = preg_replace_callback('/(?:\b|#)+(?<![`:@%])([-a-zA-Z0-9.#_]*[a-z][-a-zA-Z0-9.#_]*)(?!`)\b/', array($this, '_quoteIdentifier'), $spec);
     
         return $spec;
     }


### PR DESCRIPTION
Added ignoring strings starting with a % so you can use: DATE_FORMAT(date, "%Y-%m-%d").
