### PR TITLE
Add support for domains to ComKoowaTemplateLocator

### DIFF
--- a/code/libraries/koowa/components/com_koowa/database/table/templates.php
+++ b/code/libraries/koowa/components/com_koowa/database/table/templates.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Nooku Framework - http://nooku.org/framework
+ *
+ * @copyright   Copyright (C) 2007 - 2014 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/nooku/nooku-framework for the canonical source repository
+ */
+
+/**
+ * Database table for Joomla templates
+ *
+ * @author  Dave Li <https://github.com/daveli>
+ * @package Koowa\Component\Koowa\Database\Table
+ */
+class ComKoowaDatabaseTableTemplates extends KDatabaseTableAbstract
+{
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append(array(
+            'name' => 'template_styles'
+        ));
+
+        parent::_initialize($config);
+    }
+}

--- a/code/libraries/koowa/components/com_koowa/model/entity/template.php
+++ b/code/libraries/koowa/components/com_koowa/model/entity/template.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Nooku Framework - http://nooku.org/framework
+ *
+ * @copyright   Copyright (C) 2007 - 2014 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/nooku/nooku-framework for the canonical source repository
+ */
+
+/**
+ * Template entity
+ *
+ * @package Koowa\Component\Koowa\Model
+ */
+class ComKoowaModelEntityTemplate extends KModelEntityRow
+{
+    public function setProperties($properties, $modified = true)
+    {
+        parent::setProperties($properties, $modified);
+
+        $this->path = ($this->client_id ? JPATH_ADMINISTRATOR : JPATH_ROOT) . '/templates/' . $this->template;
+
+        return $this;
+    }
+}

--- a/code/libraries/koowa/components/com_koowa/model/templates.php
+++ b/code/libraries/koowa/components/com_koowa/model/templates.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Nooku Framework - http://nooku.org/framework
+ *
+ * @copyright   Copyright (C) 2007 - 2014 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/nooku/nooku-framework for the canonical source repository
+ */
+
+/**
+ * Templates model that wraps Joomla template data
+ *
+ * @author  Dave Li <https://github.com/daveli>
+ * @package Koowa\Component\Koowa\Model
+ */
+class ComKoowaModelTemplates extends KModelDatabase
+{
+    public function __construct(KObjectConfig $config)
+    {
+        parent::__construct($config);
+
+        $this->getState()
+            ->insert('active', 'int')
+            ->insert('sort', 'cmd', 'client_id')
+            ->insert('direction', 'word', 'asc');
+    }
+
+    protected function _buildQueryWhere(KDatabaseQueryInterface $query)
+    {
+        parent::_buildQueryWhere($query);
+
+        $state = $this->getState();
+
+        if (is_numeric($state->active)) {
+            $query->where('tbl.home = :home')->bind(array('home' => 1));
+        }
+    }
+}

--- a/code/libraries/koowa/components/com_koowa/template/locator/component.php
+++ b/code/libraries/koowa/components/com_koowa/template/locator/component.php
@@ -20,7 +20,7 @@ class ComKoowaTemplateLocatorComponent extends KTemplateLocatorComponent
      *
      * @var string
      */
-    protected $_override_path;
+    protected static $_override_paths;
 
     /**
      * Constructor.
@@ -31,26 +31,9 @@ class ComKoowaTemplateLocatorComponent extends KTemplateLocatorComponent
     {
         parent::__construct($config);
 
-        $this->_override_path = $config->override_path;
-    }
-
-    /**
-     * Initializes the options for the object
-     *
-     * Called from {@link __construct()} as a first step of object instantiation.
-     *
-     * @param  KObjectConfig $config An optional KObjectConfig object with configuration options.
-     * @return  void
-     */
-    protected function _initialize(KObjectConfig $config)
-    {
-        $template  = JFactory::getApplication()->getTemplate();
-
-        $config->append(array(
-            'override_path' => JPATH_THEMES.'/'.$template.'/html'
-        ));
-
-        parent::_initialize($config);
+        if (!isset($config->override_paths) && !self::$_override_paths) {
+            self::$_override_paths = array_values($this->getObject('com::koowa.model.templates')->active(1)->fetch()->toArray());
+        }
     }
 
     /**
@@ -72,7 +55,7 @@ class ComKoowaTemplateLocatorComponent extends KTemplateLocatorComponent
         /*
          * Theme path
          */
-        if(!empty($this->_override_path))
+        if(!empty(self::$_override_paths))
         {
             //Remove the 'view' element from the path.
             $path = $info['path'];
@@ -87,7 +70,9 @@ class ComKoowaTemplateLocatorComponent extends KTemplateLocatorComponent
                 $filepath = 'com_'.$package.'/'.implode('/', $path).'/'.$info['file'].'.'.$info['format'].'.*';
             }
 
-            $paths[] = $this->_override_path.'/'.$filepath;
+            $index = $domain === 'site' ? 0 : 1;
+
+            $paths[] = self::$_override_paths[$index]['path'].'/html/'.$filepath;
         }
 
         /*


### PR DESCRIPTION
Current behavior:

From the domain admin:
$this->getObject('com://site/foo.view.bar.default.html'); will ignore overrides in /templates/protostar/html/com_foo/bar/default.html. It will use this override /administrator/templates/isis/html/com_foo/bar/default.html.

New behavior should be:

From the domain admin:
$this->getObject('com://site/foo.view.bar.default.html'); use override /templates/protostar/html/com_foo/bar/default.html

From the site admin:
$this->getObject('com://admin/foo.view.bar.default.html'); use override /administrator/templates/isis/html/com_foo/bar/default.html