### PR TITLE
Fix typo: use get() instead of has()

### DIFF
--- a/code/dispatcher/request/abstract.php
+++ b/code/dispatcher/request/abstract.php
@@ -508,7 +508,7 @@ abstract class DispatcherRequestAbstract extends ControllerRequest implements Di
     public function getPort()
     {
         if ($this->isProxied() && $this->_headers->has('X-Forwarded-Port')) {
-            $port = $this->_headers->has('X-Forwarded-Port');
+            $port = $this->_headers->get('X-Forwarded-Port');
         } else {
             $port = @$_SERVER['SERVER_PORT'];
         }


### PR DESCRIPTION
DispatcherRequestAbstract::getPort() returns the result of the `$this->_headers->has('X-Forwarded-Port')` method instead of `$this->_headers->get('X-Forwarded-Port')`.