### PR TITLE
Initialize $_mainifests in ObjectBootstrapper to array

### DIFF
--- a/code/object/bootstrapper/bootstrapper.php
+++ b/code/object/bootstrapper/bootstrapper.php
@@ -64,7 +64,7 @@ final class ObjectBootstrapper extends Object implements ObjectBootstrapperInter
      *
      * @var array
      */
-    protected $_manifests;
+    protected $_manifests = array();
 
     /**
      * Constructor.


### PR DESCRIPTION
PHP is coercing this into an array when `registerComponent()` is called and the json file contains a `bootstrap` key. However if this is never called, it's never an array, and the foreach within `bootstrap()` fails.