### PR TITLE
Ensure $_SERVER['REMOTE_ADDR'] is set

### DIFF
--- a/code/dispatcher/request/abstract.php
+++ b/code/dispatcher/request/abstract.php
@@ -683,7 +683,7 @@ abstract class DispatcherRequestAbstract extends ControllerRequest implements Di
 
             $address   = $addresses[0];
         }
-        else $address = $_SERVER['REMOTE_ADDR'];
+        else $address = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : null;
 
         return $address;
     }


### PR DESCRIPTION
CLI doesn't define this key and errors as such.