### PR TITLE
Implement 429 too many requests HTTP response codes & exceptions

### DIFF
--- a/code/controller/exception/ratelimit.php
+++ b/code/controller/exception/ratelimit.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Kodekit - http://timble.net/kodekit
+ *
+ * @copyright   Copyright (C) 2007 - 2016 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     MPL v2.0 <https://www.mozilla.org/en-US/MPL/2.0>
+ * @link        https://github.com/timble/kodekit for the canonical source repository
+ */
+
+namespace Kodekit\Library;
+
+/**
+ * Rate Limit Controller Exception
+ *
+ * @author  Johan Janssens <https://github.com/johanjanssens>
+ * @package Kodekit\Library\Controller\Exception
+ */
+class ControllerExceptionRateLimit extends HttpExceptionTooManyRequests implements ControllerException {}

--- a/code/http/exception/toomanyrequests.php
+++ b/code/http/exception/toomanyrequests.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Kodekit - http://timble.net/kodekit
+ *
+ * @copyright   Copyright (C) 2007 - 2016 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     MPL v2.0 <https://www.mozilla.org/en-US/MPL/2.0>
+ * @link        https://github.com/timble/kodekit for the canonical source repository
+ */
+
+namespace Kodekit\Library;
+
+/**
+ * Too Many Requests Http Exception
+ *
+ * The user has sent too many requests in a given amount of time.
+ *
+ * @author  Johan Janssens <https://github.com/johanjanssens>
+ * @package Kodekit\Library\Http\Exception
+ */
+class HttpExceptionTooManyRequests extends HttpExceptionAbstract
+{
+    protected $code = HttpResponse::TOO_MANY_REQUESTS;
+}

--- a/code/http/response/response.php
+++ b/code/http/response/response.php
@@ -42,20 +42,20 @@ class HttpResponse extends HttpMessage implements HttpResponseInterface
     protected $_content_type;
 
     // [Successful 2xx]
-    const OK                        = 200;
-    const CREATED                   = 201;
-    const ACCEPTED                  = 202;
-    const NO_CONTENT                = 204;
-    const RESET_CONTENT             = 205;
-    const PARTIAL_CONTENT           = 206;
+    const OK                            = 200;
+    const CREATED                       = 201;
+    const ACCEPTED                      = 202;
+    const NO_CONTENT                    = 204;
+    const RESET_CONTENT                 = 205;
+    const PARTIAL_CONTENT               = 206;
 
     // [Redirection 3xx]
-    const MOVED_PERMANENTLY         = 301;
-    const FOUND                     = 302;
-    const SEE_OTHER                 = 303;
-    const NOT_MODIFIED              = 304;
-    const USE_PROXY                 = 305;
-    const TEMPORARY_REDIRECT        = 307;
+    const MOVED_PERMANENTLY             = 301;
+    const FOUND                         = 302;
+    const SEE_OTHER                     = 303;
+    const NOT_MODIFIED                  = 304;
+    const USE_PROXY                     = 305;
+    const TEMPORARY_REDIRECT            = 307;
 
     // [Client Error 4xx]
     const BAD_REQUEST                   = 400;
@@ -74,14 +74,15 @@ class HttpResponse extends HttpMessage implements HttpResponseInterface
     const UNSUPPORTED_MEDIA_TYPE        = 415;
     const REQUESTED_RANGE_NOT_SATISFIED = 416;
     const EXPECTATION_FAILED            = 417;
+    const TOO_MANY_REQUESTS             = 429;
 
     // [Server Error 5xx]
-    const INTERNAL_SERVER_ERROR     = 500;
-    const NOT_IMPLEMENTED           = 501;
-    const BAD_GATEWAY               = 502;
-    const SERVICE_UNAVAILABLE       = 503;
-    const GATEWAY_TIMEOUT           = 504;
-    const VERSION_NOT_SUPPORTED     = 505;
+    const INTERNAL_SERVER_ERROR         = 500;
+    const NOT_IMPLEMENTED               = 501;
+    const BAD_GATEWAY                   = 502;
+    const SERVICE_UNAVAILABLE           = 503;
+    const GATEWAY_TIMEOUT               = 504;
+    const VERSION_NOT_SUPPORTED         = 505;
 
     /**
      * Status codes translation table.


### PR DESCRIPTION
# What

Implement 429 too many requests HTTP response codes & exceptions.
HTTP status code set in HttpResponse
HTTP TooManyRequests exception
Controller RateLimit exception
# Why

Applications may wish to do rate limiting at the domain level, this should be supported by the framework. 
