### PR TITLE
Patch bootstrapper

### DIFF
--- a/code/object/bootstrapper/bootstrapper.php
+++ b/code/object/bootstrapper/bootstrapper.php
@@ -222,6 +222,8 @@ final class ObjectBootstrapper extends Object implements ObjectBootstrapperInter
                     }
                 }
 
+                $identifiers = array();
+                $aliases = array();
                 foreach($this->_files as $path)
                 {
                     $array = $factory->fromFile($path, false);


### PR DESCRIPTION
# What
Fix some undefined variable erros & cache extended components to a local variable for performance

# Why
2 variables are undefined if you don't bootstrap any components.
Also, iterating over the whole list of manifests twice is unnecessary, cache each component that is extending another and only iterate those extended components.