### PR TITLE
Auto connect to DB on first query

### DIFF
--- a/code/database/driver/abstract.php
+++ b/code/database/driver/abstract.php
@@ -196,13 +196,18 @@ abstract class DatabaseDriverAbstract extends Object implements DatabaseDriverIn
      * Provides access to the underlying database connection. Useful for when
      * you need to call a proprietary method such as postgresql's lo_* methods
      *
-     * @param bool $autoconnect If connection hasn't been established, auto connect
+     * @param bool $auto_connect If connection hasn't been established, auto connect
      * @return resource
+     * @throws \RuntimeException if auto connection fails
      */
-    public function getConnection($autoconnect = true)
+    public function getConnection($auto_connect = true)
     {
-        if (!$this->_connection && $autoconnect) {
+        if (!$this->_connection && $auto_connect) {
             $this->connect();
+
+            if (!$this->_connection) {
+                throw new \RuntimeException('Database auto connection failed');
+            }
         }
 
         return $this->_connection;

--- a/code/database/driver/abstract.php
+++ b/code/database/driver/abstract.php
@@ -196,10 +196,15 @@ abstract class DatabaseDriverAbstract extends Object implements DatabaseDriverIn
      * Provides access to the underlying database connection. Useful for when
      * you need to call a proprietary method such as postgresql's lo_* methods
      *
+     * @param bool $autoconnect If connection hasn't been established, auto connect
      * @return resource
      */
-    public function getConnection()
+    public function getConnection($autoconnect = true)
     {
+        if (!$this->_connection && $autoconnect) {
+            $this->connect();
+        }
+
         return $this->_connection;
     }
 

--- a/code/database/driver/interface.php
+++ b/code/database/driver/interface.php
@@ -44,9 +44,10 @@ interface DatabaseDriverInterface
      * Provides access to the underlying database connection. Useful for when you need to call a proprietary method
      * on the database driver
      *
+     * @param bool $autoconnect If connection hasn't been established, auto connect
      * @return resource
      */
-    public function getConnection();
+    public function getConnection($autoconnect = true);
 
     /**
      * Set the connection

--- a/code/database/driver/interface.php
+++ b/code/database/driver/interface.php
@@ -44,10 +44,11 @@ interface DatabaseDriverInterface
      * Provides access to the underlying database connection. Useful for when you need to call a proprietary method
      * on the database driver
      *
-     * @param bool $autoconnect If connection hasn't been established, auto connect
+     * @param bool $auto_connect If connection hasn't been established, auto connect
      * @return resource
+     * @throws \RuntimeException if auto connection fails
      */
-    public function getConnection($autoconnect = true);
+    public function getConnection($auto_connect = true);
 
     /**
      * Set the connection


### PR DESCRIPTION
# What
Auto connect to DB the first time a connection is required

# Why
If you don't have auto connect enabled for the driver itself, the connection isn't established when executing a query resulting in a call to a non-object