### PR TITLE
Return false for ModelEntity::hasProperty() if argument is falsy

### DIFF
--- a/code/model/entity/abstract.php
+++ b/code/model/entity/abstract.php
@@ -269,10 +269,6 @@ abstract class ModelEntityAbstract extends ObjectArray implements ModelEntityInt
      */
     public function hasProperty($name)
     {
-        if (empty($name)) {
-            return false;
-        }
-
         $result = false;
 
         //Handle computed properties
@@ -284,7 +280,7 @@ abstract class ModelEntityAbstract extends ObjectArray implements ModelEntityInt
                 $result = true;
             }
         }
-        else $result = true;
+        elseif (!empty($name)) $result = true;
 
         return $result;
     }

--- a/code/model/entity/abstract.php
+++ b/code/model/entity/abstract.php
@@ -271,16 +271,20 @@ abstract class ModelEntityAbstract extends ObjectArray implements ModelEntityInt
     {
         $result = false;
 
-        //Handle computed properties
-        if(!parent::offsetExists($name))
+        //Ensure property has a name
+        if (!empty($name)) 
         {
-            $properties = $this->getComputedProperties();
-
-            if(isset($properties[$name])) {
-                $result = true;
+            //Handle computed properties
+            if(!parent::offsetExists($name))
+            {
+                $properties = $this->getComputedProperties();
+    
+                if(isset($properties[$name])) {
+                    $result = true;
+                }
             }
+            else $result = true;
         }
-        elseif (!empty($name)) $result = true;
 
         return $result;
     }

--- a/code/model/entity/abstract.php
+++ b/code/model/entity/abstract.php
@@ -269,10 +269,14 @@ abstract class ModelEntityAbstract extends ObjectArray implements ModelEntityInt
      */
     public function hasProperty($name)
     {
+        if (empty($name)) {
+            return false;
+        }
+
         $result = false;
 
         //Handle computed properties
-        if(!parent::offsetExists($name) && !empty($name))
+        if(!parent::offsetExists($name))
         {
             $properties = $this->getComputedProperties();
 


### PR DESCRIPTION
# What

Return false for ModelEntity::hasProperty() if argument is falsy
# Why

Found this bug when using a model with a JSON view when the model isn't backed by a DB, thus no primary key, and '' is passed to it when `getIdentityKey()` is called.
