### PR TITLE
Add missing setMimeType() method to ViewAbstract

### DIFF
--- a/code/view/abstract.php
+++ b/code/view/abstract.php
@@ -437,6 +437,18 @@ abstract class ViewAbstract extends Object implements ViewInterface, CommandCall
     }
 
     /**
+     * Set the view mimetype
+     *
+     * @param string $mimetype The mimetype to set
+     * @return ViewAbstract
+     */
+    public function setMimetype($mimetype)
+    {
+        $this->__mimetype = $mimetype;
+        return $this;
+    }
+
+    /**
      * Returns the views output
      *
      * @return string


### PR DESCRIPTION
# What

Add missing setMimeType() method to ViewAbstract, else this calls the magic `__call()` method and ends up setting a property called `setMimeType`.
# Why

The view is missing a `setMimetype()` method, that is called: https://github.com/timble/kodekit/blob/master/code/view/abstract.php#L87
# Note

It's also worth noting, that this https://github.com/timble/kodekit/blob/master/code/view/abstract.php#L535 allows for any protected/private method that starts with `set` to be called from the public scope, this is bad 😞 
