### PR TITLE
Pass view name from query string if set

### DIFF
--- a/code/controller/view.php
+++ b/code/controller/view.php
@@ -83,7 +83,11 @@ abstract class ControllerView extends ControllerAbstract implements ControllerVi
         {
             //Make sure we have a view identifier
             if(!($this->_view instanceof ObjectIdentifier)) {
-                $this->setView($this->_view);
+                if(!$this->getRequest()->query->has('view')) {
+                    $this->setView($this->_view);
+                } else {
+                    $this->setView($this->getRequest()->query->get('view', 'cmd'));
+                }
             }
 
             //Create the view


### PR DESCRIPTION
# What
Pass view name from query string if set, consistent with https://github.com/timble/kodekit/blob/master/code/controller/model.php#L75

# Why
Controller names are always singular, but views could be plural. The model controller uses query string variable if set, seems logical that the view controller should do the same...