### PR TITLE
Ensure HttpUrl::setUrl() verifies $parts is an array

### DIFF
--- a/code/http/url/url.php
+++ b/code/http/url/url.php
@@ -230,8 +230,10 @@ class HttpUrl extends Object implements HttpUrlInterface
             $parts = $url;
         }
 
-        foreach ($parts as $key => $value) {
-            $this->$key = $value;
+        if (is_array($parts)) {
+            foreach ($parts as $key => $value) {
+                $this->$key = $value;
+            }
         }
 
         return $this;


### PR DESCRIPTION
If `parse_url()` fails, `$parts` is not an array so it can't be iterated.