### PR TITLE
Allow unknown column types for mysqli filters

### DIFF
--- a/code/database/driver/mysqli.php
+++ b/code/database/driver/mysqli.php
@@ -569,7 +569,7 @@ class DatabaseDriverMysqli extends DatabaseDriverAbstract
         $column->primary  = $info->Key == 'PRI';
         $column->unique   = ($info->Key == 'UNI' || $info->Key == 'PRI');
         $column->autoinc  = strpos($info->Extra, 'auto_increment') !== false;
-        $column->filter   = $this->_type_map[$type];
+        $column->filter   = isset($this->_type_map[$type]) ? $this->_type_map[$type] : 'raw';
 
         // Don't keep "size" for integers.
         if(substr($type, -3) == 'int') {


### PR DESCRIPTION
Default mysql column filter to "raw" for unknown column types, like "geometry" in mysql 5.6. This allows for forwards compatibility with future versions of mysql. Default for `raw` to ensure value is not filtered as it's unknown.

Additionally, making the filter list configurable would be 👍 
