### PR TITLE
Add ViewAbstract::setMimetype()

### DIFF
--- a/code/view/abstract.php
+++ b/code/view/abstract.php
@@ -420,6 +420,17 @@ abstract class ViewAbstract extends Object implements ViewInterface, CommandCall
     {
         return $this->__mimetype;
     }
+    
+    /**
+     * Set the mimetype
+     *
+     * @return ViewAbstract
+     */
+    public function setMimetype($mimetype)
+    {
+        $this->__mimetype = $mimetype;
+        return $this;
+    }
 
     /**
      * Returns the views output


### PR DESCRIPTION
View requires a setter for mimetype or calling `setMimetype()` sets a property of `setMimeype` to the actual mime type. Due to the `__call()` method being fluent, if a setter doesn't specifically exist, then a property of that name is set.
